### PR TITLE
WIP Feature/minio build for devels

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,4 @@
+## Support
 Please, review these links:
 
 http://www.smorgasbork.com/2014/07/16/building-a-custom-centos-7-kickstart-disc-part-1/
@@ -5,12 +6,29 @@ http://kfei.logdown.com/posts/143152-build-your-own-customized-install-disc-from
 https://fedoraproject.org/wiki/QA:Testcase_Kickstart_File_Path_Ks_Cfg
 https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/chap-anaconda-boot-options.html#list-boot-options-sources
 
+## Description
+This repository is a collection of other repositories but boosted with build scripts. For example with minio, the primal package is downloaded to adapt it to our packaging system, generating the rpms and the iso.
+
+### Building one package
+build_modules -m <module_name>
+
+### Building minio and uploading to devel
+This command will build minio and upload it to devel's rbrepo
+```
+sudo DEVEL=<devel_name> VERSION=<x.y.z> ./build_module.sh -m minio
+```
+for example
+```
+sudo DEVEL=ljblanco VERSION=13550.0.0 ./build_module.sh -m minio
+```
+
+## Requirements
 Packages needed:
 
 Mock:
 # yum install epel-release
 # yum install mock
 
-Content:
+## Content
 sdk7.cfg => Config file for running mock for a Centos 7
 sdk9.cfg => Config file for running mock for a Rocky 9

--- a/README
+++ b/README
@@ -17,10 +17,6 @@ This command will build minio and upload it to devel's rbrepo
 ```
 sudo DEVEL=<devel_name> VERSION=<x.y.z> ./build_module.sh -m minio
 ```
-for example
-```
-sudo DEVEL=ljblanco VERSION=13550.0.0 ./build_module.sh -m minio
-```
 
 ## Requirements
 Packages needed:

--- a/build_common.sh
+++ b/build_common.sh
@@ -7,9 +7,19 @@ f_rsync_repo() {
 	rsync -av -e "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" ${LIST} root@rbrepo.redborder.lan:/repos/ng/latest/rhel/9/x86_64/
 }
 
+f_rsync_devel_repo() {
+	local LIST="$@"
+	rsync -av -e "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" ${LIST} root@rbrepo.redborder.lan:/repos/ng/devel/${DEVEL}/rhel/9/x86_64/
+}
+
 f_rsync_repo_SRPMS() {
 	local LIST="$@"
 	rsync -av -e "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" ${LIST} root@rbrepo.redborder.lan:/repos/ng/latest/rhel/9/SRPMS/
+}
+
+f_rsync_devel_repo_SRPMS() {
+	local LIST="$@"
+	rsync -av -e "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" ${LIST} root@rbrepo.redborder.lan:/repos/ng/devel/${DEVEL}/rhel/9/SPRMS/
 }
 
 f_rsync_iso() {
@@ -83,19 +93,19 @@ f_rupdaterepo() {
 	return $ret
 }
 
-
 f_check() {
 	# need to check if the packages exist
+	echo Starting to check packages exist
 	local list_of_packages="$@"
 	local create_rpms=0
 	for package in ${list_of_packages}; do
 		f_ssh_rbrepo test -e ${package}
 		if [ $? -eq 0 ]; then
-        		f_ssh_rbrepo file --mime-type -b ${package} | grep -q "application/x-rpm"
-        		if [ $? -ne 0 ]; then
+			f_ssh_rbrepo file --mime-type -b ${package} | grep -q "application/x-rpm"
+			if [ $? -ne 0 ]; then
 				create_rpms=1
 				break
-        	        fi
+			fi
 		else
 			create_rpms=1
 			break

--- a/build_module.sh
+++ b/build_module.sh
@@ -32,14 +32,14 @@ f_build() {
                         echo "Something was wrong ... exiting"
                         ret=1
                     else
-                        # module built successfuly
+                        # echo 'module built successfuly'
                         modules[${moduledep}]=1
                     fi
                 fi
             done
         fi
         if [ $ret -eq 0 ]; then
-            # now, build the module
+            # echo 'Building the module'
             if [ -x ${opt_dir}/$module/build.sh ]; then
                 pushd ${opt_dir}/$module &>/dev/null
                 echo "Building module: $module"

--- a/modules/minio/build.sh
+++ b/modules/minio/build.sh
@@ -7,19 +7,26 @@ RELEASE=${RELEASE:="2"}
 MINIORELEASE=${MINIORELEASE:="20230125001954"}
 PACKNAME=${PACKNAME:="minio"}
 CACHEDIR=${CACHEDIR:="/isos/ng/latest/rhel/9/x86_64"}
-REPODIR=${REPODIR:="/repos/ng/latest/rhel/9/x86_64"}
-REPODIR_SRPMS=${REPODIR_SRPMS:="/repos/ng/latest/rhel/9/SRPMS"}
+
+if [ "x${DEVEL}" == "x" ]; then
+  REPODIR=${REPODIR:="/repos/ng/latest/rhel/9/x86_64"}
+  REPODIR_SRPMS=${REPODIR_SRPMS:="/repos/ng/latest/rhel/9/SRPMS"}
+else
+  REPODIR=${REPODIR:="/repos/ng/devel/${DEVEL}/rhel/9/x86_64"}
+  REPODIR_SRPMS=${REPODIR_SRPMS:="/repos/ng/devel/${DEVEL}/rhel/9/SRPMS"}
+fi
 
 list_of_packages="${REPODIR_SRPMS}/${PACKNAME}-${VERSION}-${RELEASE}.el9.rb.src.rpm 
-                ${REPODIR}/${PACKNAME}-${VERSION}-${RELEASE}.el9.rb.x86_64.rpm 
-                ${CACHEDIR}/${PACKNAME}-${VERSION}-${RELEASE}.el9.rb.x86_64.rpm"
+                  ${REPODIR}/${PACKNAME}-${VERSION}-${RELEASE}.el9.rb.x86_64.rpm 
+                  ${CACHEDIR}/${PACKNAME}-${VERSION}-${RELEASE}.el9.rb.x86_64.rpm"
 
+echo 'Starting to build minio'
 if [ "x$1" != "xforce" ]; then
-        f_check "${list_of_packages}"
-        if [ $? -eq 0 ]; then
-                # the rpms exist and we don't need to create again
-                exit 0
-        fi
+  f_check "${list_of_packages}"
+  if [ $? -eq 0 ]; then
+    echo the rpms exist and we do not need to create again
+    exit 0
+  fi
 fi
 
 # First we need to download source
@@ -28,7 +35,9 @@ rm -rf pkgs
 mkdir SOURCES
 mkdir pkgs
 pushd SOURCES &>/dev/null
-wget --no-check-certificate https://dl.minio.io/server/minio/release/linux-amd64/archive/${PACKNAME}-${MINIORELEASE}.0.0.x86_64.rpm 
+
+MINIO_FILE="${PACKNAME}-${MINIORELEASE}.0.0.x86_64.rpm"
+wget --no-check-certificate "https://dl.minio.io/server/minio/release/linux-amd64/archive/${MINIO_FILE}"
 rpm2cpio ${PACKNAME}-${MINIORELEASE}.0.0.x86_64.rpm | cpio -idmv && mv /usr/local/bin/minio .    #Extract the executable and move it to SOURCES
 rm -f /etc/systemd/system/minio.service                                                   #Remove other extracted files that we don't want from our system
 popd &>/dev/null
@@ -53,10 +62,18 @@ if [ $ret -ne 0 ]; then
 fi
 
 # sync to cache and repo
-f_rsync_repo pkgs/*.x86_64.rpm
-f_rsync_repo_SRPMS pkgs/*.src.rpm
-f_rsync_iso pkgs/*.x86_64.rpm
+echo 'Sync rpm'
+if [ "x${DEVEL}" == "x" ]; then
+  f_rsync_repo pkgs/*.x86_64.rpm
+  f_rsync_repo_SRPMS pkgs/*.src.rpm
+  f_rsync_iso pkgs/*.x86_64.rpm
+else
+  f_rsync_devel_repo pkgs/*.x86_64.rpm
+  f_rsync_devel_repo_SRPMS pkgs/*.src.rpm
+  # f_rsync_iso pkgs/*.x86_64.rpm
+fi
 
+echo Removing packages from local
 rm -rf pkgs
 rm -rf SOURCES
 


### PR DESCRIPTION
We need to determine if this is a task or not. I just find helpful these changes to develop, but the changes are not general for this repo and the adjust is going to be greater if want to normalize the workflow. Any way, when building minio now we can:

DEVEL=<devel_name> build_modules -m minio

and minio packages will go to devel rbrepo directory